### PR TITLE
Remove iframe body margin

### DIFF
--- a/src/server/iframe.html.js
+++ b/src/server/iframe.html.js
@@ -7,6 +7,11 @@ export default function (headHtml, publicPath) {
       <head>
         <meta charset="utf-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
+        <style>
+          body {
+            margin: 0;
+          }
+        </style>
         <script>
           if (window.parent !== window) {
             window.__REACT_DEVTOOLS_GLOBAL_HOOK__ = window.parent.__REACT_DEVTOOLS_GLOBAL_HOOK__;


### PR DESCRIPTION
Remove the margin added by the browser by default. Necessary padding can be easily added with decorators when needed but it's difficult to remove.

```
storiesOf('MyComponent', module)
  .addDecorator(f => <div style={{margin: '8px'}}>f()</div>)
```
